### PR TITLE
Linking directly to settings workaround

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-Spec-Template-blank.md
+++ b/.github/ISSUE_TEMPLATE/02-Spec-Template-blank.md
@@ -28,7 +28,7 @@
 
 ## Logs
 
-## Your environment
+## Config
 
 ## Self-service
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ We are not affiliated with Serif or Canva.
 - [Heroic Games Launcher](./Guides/Heroic/Guide.md)
 - [Lutris](./Guides/Lutris/Guide.md) (Recommended)
 
+### Caveats
+
+UI settings sometimes don't save. There is a [workaround](Guides/Settings.md).
+
 ### Miscellaneous 
 
 [Known issues ⚠️](/Known-issues.md)


### PR DESCRIPTION
Linking directly to the settings workaround guide from `./README.md`
Updated spec issue template.
