### PR TITLE
Move warning about V1 product keys into main README

### DIFF
--- a/Guides/Rum/Guide.md
+++ b/Guides/Rum/Guide.md
@@ -2,10 +2,6 @@
 
 ## Preface
 
-> [!WARNING]
-> Be advised that, if you purchased the old **V1 version** of your Affinity software(s) through the **Windows store**, you will **not** be able to activate your old licence on another OS.  
-> The Windows Store just doesn't provide the product key you will need to enter after the installation, so, if you want to stay on Linux and not upgrade to V2 your only option is to use a virtual machine.  
-
 This guide aims to provide a way to manage wine that does not make use of launchers like Lutris or Bottles.  
 We will instead use `rum`, a small shell script that will help us manage multiple wine runners.
 

--- a/README.md
+++ b/README.md
@@ -26,15 +26,17 @@ These guides help with step by step installation of Serif's Affinity apps using 
 - [Lutris](./Guides/Lutris/Guide.md) (Recommended)
 - [Rum](./Guides/Rum/Guide.md) 
 
-### Information 
+### Information
+
+> [!WARNING]
+> Be advised that, if you purchased the old **1.X version** of the Affinity applications through the [**Windows Store**](https://apps.microsoft.com/), you will **not** be able to activate your old licence on another operating systems other than Windows.  
+> The Windows Store does not provide the product key you will need to enter after the installation, so, if you want to stay on Linux and don't want to buy a V2 licence (since V1 isn't sold anymore), your only option is to use a Windows virtual machine, sign into your Microsoft account on the Windows Store, and download your V1 apps from there.
 
 [FAQ ❓](/FAQ.md)
   - [Backup Mirrors](https://github.com/seapear/AffinityOnLinux/blob/main/FAQ.md#use-these-if-the-main-mirrors-are-down)
   - UI settings sometimes don't save. There is a [workaround](Guides/Settings.md).
 
 [🗺️ Roadmap & ⚠️ Known issues](/Roadmap.md)
-
-[🎨 Featured stuff](/Featured/FEATURED-1.MD)
 
 [📜 Credits](/Credits.md)
 


### PR DESCRIPTION
- also remove dead `Featured stuff` link

Maybe fact-check me about this, just to make sure, but from what I read around the Affinity forum, there is no way recover the product key from an Affinity App bought from the Windows Store.