### PR TITLE
Fix Bottles download page link and use official Linux distro names

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -13,17 +13,18 @@ As users of AffinityOnLinux ourselves, we know firsthand how valuable this tool 
 
 ---
 
-## How to use this Guide:
-1. Check to see if your OS is compatable: ([Tested OS](#tested-methods))
-2. Choose an Installer: [Lutris](https://lutris.net/), [Heroic Games Launcher](https://heroicgameslauncher.com/), [Bottles](https://usebottles.com/) or [Rum](https://gitlab.com/xkero/rum).
-3. Choose your guide you feel suits your needs: 
+## How to Use This Guide:
+
+1. Check if your Linux distribution is compatable: [Tested distros](#tested-methods)
+2. Choose a Wine manager: [Lutris](https://lutris.net/), [Heroic Games Launcher](https://heroicgameslauncher.com/), [Bottles](https://usebottles.com/) or [Rum](https://gitlab.com/xkero/rum).
+3. Choose a guide based on your Wine manager of choice: 
   - [Lutris](./Guides/Lutris/Guide.md) (Recommended)
   - [Heroic Games Launcher](./Guides/Heroic/Guide.md)
   - [Bottles](./Guides/Bottles/Guide.md)
   - [Rum](./Guides/Rum/Guide.md) (terminal)
-4. Post any issues or bugs you find in the github [Issues](https://github.com/seapear/AffinityOnLinux/issues) tab, or on the [Discord](https://discord.gg/t5V9ecpJWZ) in the Help channel.
-5. If you have a fix or a solution, submit a [Pull Request](https://github.com/seapear/AffinityOnLinux/pulls) and let us know in #feedback on the [Discord](https://discord.gg/t5V9ecpJWZ).
-6. Finally grab your ✔️Success Badge on the [Discord](https://discord.gg/t5V9ecpJWZ), we would be love to hear about your real world use of AOL!
+4. Report any issues or bugs you find in our repository's [Issues](https://github.com/seapear/AffinityOnLinux/issues) tab, or on our [Discord](https://discord.gg/t5V9ecpJWZ) in the Help channel.
+5. If you have a fix or a solution for our guides, submit a [Pull Request](https://github.com/seapear/AffinityOnLinux/pulls) and let us know in #feedback on our [Discord](https://discord.gg/t5V9ecpJWZ).
+6. Finally, grab your ✔️Success Badge on our [Discord](https://discord.gg/t5V9ecpJWZ), we would be love to hear about your real world use of AffinityOnLinux!
 
 
 ## 🛠️ Usage

--- a/FAQ.md
+++ b/FAQ.md
@@ -32,7 +32,7 @@ As users of AffinityOnLinux ourselves, we know firsthand how valuable this tool 
 ### Which Affinity versions are supported?
 *Affinity v1 and v2 both work in most cases using this tutorial.*
 > [!TIP]
-> Official installers download links:
+> Official Affinity installers download links:
 >
 > | Program | URL |
 > |---------|-----|
@@ -47,15 +47,15 @@ As users of AffinityOnLinux ourselves, we know firsthand how valuable this tool 
 
 ### 🧪 Tested Methods
 
-| OS\Method | [Lutris](https://lutris.net/) | [Heroic](https://heroicgameslauncher.com/) | [Bottles](https://usebottles.com/) | [Rum](https://gitlab.com/xkero/rum) |
-|-----------|--------|--------|---------|-----|
+| Distro/Method | [Lutris](https://lutris.net/) | [Heroic](https://heroicgameslauncher.com/) | [Bottles](https://usebottles.com/) | [Rum](https://gitlab.com/xkero/rum) |
+|---------------|--------|--------|---------|-----|
 | [Debian](https://www.debian.org/)    | ✔️     | ✔️     | ✔️     | ✔️  |
-| [Fedora](https://fedoraproject.org/)    | ✔️     | ✔️     | ✔️     | ✔️  |
-| [Arch](https://archlinux.org/)      | ✔️     | ✔️     | ✔️     | ✔️  |
+| [Fedora Linux](https://fedoraproject.org/)    | ✔️     | ✔️     | ✔️     | ✔️  |
+| [Arch Linux](https://archlinux.org/)      | ✔️     | ✔️     | ✔️     | ✔️  |
 | [Ubuntu](https://ubuntu.com/)    | ✔️     | ✔️     | ✔️     | ✔️  |
-| [Zorin](https://zorin.com/os/)     | ❌     | ❌     | ❌     | ❓  | 
-| [Cachy](https://cachyos.org/)     | ✔️     | ✔️     | ❓     | ✔️  |
-| [Endevor](https://endeavouros.com/)   | ✔️     | ✔️     | ❓     | ✔️  |
+| [Zorin OS](https://zorin.com/os/)     | ❌     | ❌     | ❌     | ❓  | 
+| [CachyOS](https://cachyos.org/)     | ✔️     | ✔️     | ❓     | ✔️  |
+| [EndeavourOS](https://endeavouros.com/)   | ✔️     | ✔️     | ❓     | ✔️  |
 | [Nobara](https://nobaraproject.org/)   | ✔️     | ✔️     | ❓     | ✔️  |
 | [SteamOS](https://store.steampowered.com/steamos)   | ✔️     | ✔️     | ❓     | ❓  |
 

--- a/Guides/Bottles/Guide.md
+++ b/Guides/Bottles/Guide.md
@@ -4,7 +4,7 @@
 
 ## 1. Install Bottles
 
-Visit the [download page of Bottles' official website](https://heroicgameslauncher.com/downloads), and follow the instructions to download and install Bottles. [Flatpak](https://flathub.org/apps/com.usebottles.bottles) is recommended, as it is the only officially supported install method for Bottles.
+Visit the [download page of Bottles' official website](https://usebottles.com/download/), and follow the instructions to download and install Bottles. [Flatpak](https://flathub.org/apps/com.usebottles.bottles) is recommended, as it is the only officially supported install method for Bottles.
 
 Alternately, you may want to install Bottles using the [unofficial AppImage](https://github.com/ivan-hc/Bottles-appimage).
 
@@ -44,8 +44,11 @@ The Affinity app should now work inside that Bottle.
 
 ## Additional Tips and Tricks
 
-### Common locations:
-`/home/$USER/.var/app/com.usebottles.bottles/data/bottles/bottles/Affinity/drive_c`
+### Common Location
+
+The Affinity apps installed with Bottles are located at the following location:
+
+- **Flatpak**: `~/.var/app/com.usebottles.bottles/data/bottles/bottles/Affinity/drive_c`
 
 ### How to Fix Studdering
 Bottles -> Settings -> # Performance | Toggle on Feral GameMode

--- a/Guides/Lutris/Guide.md
+++ b/Guides/Lutris/Guide.md
@@ -17,7 +17,7 @@ For Debian- or Ubuntu-based distros, run the command:
 sudo apt install winetricks
 ```
 
-For Fedora-based distros, run the command:
+For Fedora Linux-based distros, run the command:
 ```shell
 sudo dnf install winetricks
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _A repository containing information on how to get Affinity software working on 
   </a>
 </div>
 
-## How to use this Guide:
+## How to Use This Guide:
 
 1. Check if your Linux distributon is compatable in [FAQ ❓](/FAQ.md#tested-methods).
 2. Choose a Wine manager: [Lutris](https://lutris.net/), [Heroic Games Launcher](https://heroicgameslauncher.com/), [Bottles](https://usebottles.com/) or [Rum](https://gitlab.com/xkero/rum).


### PR DESCRIPTION
This PR aims to fix the link to Bottles' download page, and use the official names of Linux distributions.

In addition, the "How to Use This Guide" section in the FAQ page will have consistent formats as the main README.