### PR TITLE
Rum: Set the renderer to vulkan in a separate step.

### DIFF
--- a/Guides/Rum/Guide.md
+++ b/Guides/Rum/Guide.md
@@ -135,7 +135,15 @@ wine-ew-affinity wineboot --init
 Now run winetricks with the following options to install all the needed dependencies in your Affinity prefix:
 
 ```bash
-wine-ew-affinity winetricks --unattended --force remove_mono vcrun2022 dotnet48 renderer=vulkan corefonts win11
+wine-ew-affinity winetricks --unattended --force remove_mono vcrun2022 dotnet48  corefonts win11
+```
+
+> [!NOTE]
+> We set the renderer to vulkan in a separate step, after all the previews winetricks have been applied.
+
+
+```bash
+wine-ew-affinity winetricks renderer=vulkan
 ```
 
 > [!NOTE]


### PR DESCRIPTION
I noticed that Affinity Photo seemed quite slow in repainting the window during resizing, so I checked the renderer, and I was using d3d.  
Apparently vulkan wasn't set correctly if done together with all the other winetricks, so we do it separately.