### PR TITLE
Elaborate instructions for enabling dark theme for Wine

### DIFF
--- a/Guides/Bottles/Guide.md
+++ b/Guides/Bottles/Guide.md
@@ -54,9 +54,17 @@ The Affinity apps installed with Bottles are located at the following location:
 - **Flatpak**: `~/.var/app/com.usebottles.bottles/data/bottles/bottles/Affinity/drive_c`
 
 ### How to Fix Studdering
+
 - Bottles -> Settings -> # Performance | Toggle on Feral GameMode
 - Bottles -> Settings -> # Compatibility | Windows 10 -> Windows 11 [*](https://discord.com/channels/1281706644073611358/1289640098589315174/1418124555406544956)
-
 ### Dark Theme for Wine
 
-To enable the dark theme for Wine, run [this registry file](/wine-dark-theme.reg) inside the Wine prefix.
+1. Visit the [wine-dark-theme registry file](/Auxillary/Other/wine-dark-theme.reg) from this repository, and download the file by clicking the download button on the top right.
+2. In the folder where you downloaded the registry file into, run the following command:
+   ```shell
+   wine regedit wine-dark-theme.reg
+   ```
+3. If you also want to enable dark theme for the Wine fork for your installed Affinity apps on Bottles, run the command:
+    ```shell
+   WINEPREFIX="$HOME/.var/app/com.usebottles.bottles/data/bottles/bottles/Affinity" wine regedit wine-dark-theme.reg
+   ```

--- a/Guides/Heroic/Guide.md
+++ b/Guides/Heroic/Guide.md
@@ -91,7 +91,7 @@ Quote from **darkside99**:
    ```
 3. If you also want to enable dark theme for the Wine fork for your installed Affinity apps on Heroic Games Launcher, run the command:
     ```shell
-   WINEPREFIX="$HOME/path/to/wineprefix/folder" wine regedit wine-dark-theme.reg
+   WINEPREFIX="/path/to/wineprefix/folder" wine regedit wine-dark-theme.reg
    ```
    - To check your Affinity app's Wine prefix, launch Heroic Games Launcher, then click an Affinity app. Under the **INSTALL INFO** section, check the **WinePrefix folder**.
-   - Replace `$HOME/path/to/wineprefix/folder` in the command above with the WinePrefix folder location of your installed Affinity app.
+   - Replace `/path/to/wineprefix/folder` in the command above with the WinePrefix folder location of your installed Affinity app.

--- a/Guides/Heroic/Guide.md
+++ b/Guides/Heroic/Guide.md
@@ -94,4 +94,4 @@ Quote from **darkside99**:
    WINEPREFIX="$HOME/path/to/wineprefix/folder" wine regedit wine-dark-theme.reg
    ```
    - To check your Affinity app's Wine prefix, launch Heroic Games Launcher, then click an Affinity app. Under the **INSTALL INFO** section, check the **WinePrefix folder**.
-   - Replace `$HOME/path/to/wineprefix/folder` with the WinePrefix folder location of your installed Affinity app.
+   - Replace `$HOME/path/to/wineprefix/folder` in the command above with the WinePrefix folder location of your installed Affinity app.

--- a/Guides/Heroic/Guide.md
+++ b/Guides/Heroic/Guide.md
@@ -84,4 +84,14 @@ Quote from **darkside99**:
 
 ### Dark Theme for Wine
 
-To enable the dark theme for Wine, run [this registry file](/wine-dark-theme.reg) inside the Wine prefix.
+1. Visit the [wine-dark-theme registry file](/Auxillary/Other/wine-dark-theme.reg) from this repository, and download the file by clicking the download button on the top right.
+2. In the folder where you downloaded the registry file into, run the following command:
+   ```shell
+   wine regedit wine-dark-theme.reg
+   ```
+3. If you also want to enable dark theme for the Wine fork for your installed Affinity apps on Heroic Games Launcher, run the command:
+    ```shell
+   WINEPREFIX="$HOME/path/to/wineprefix/folder" wine regedit wine-dark-theme.reg
+   ```
+   - To check your Affinity app's Wine prefix, launch Heroic Games Launcher, then click an Affinity app. Under the **INSTALL INFO** section, check the **WinePrefix folder**.
+   - Replace `$HOME/path/to/wineprefix/folder` with the WinePrefix folder location of your installed Affinity app.

--- a/Guides/Lutris/Guide.md
+++ b/Guides/Lutris/Guide.md
@@ -128,4 +128,14 @@ Note that these Wine configuration settings will apply to all Affinity apps you 
 
 ### Dark Theme for Wine
 
-To enable the dark theme for Wine, run [this registry file](/wine-dark-theme.reg) inside the Wine prefix.
+To enable the dark theme for Wine, follow these steps:
+
+1. Visit the [wine-dark-theme registry file](/Auxillary/Other/wine-dark-theme.reg) from this repository, and download the file by clicking the download button on the top right.
+2. In the folder where you downloaded the registry file into, run the following command:
+   ```shell
+   wine regedit wine-dark-theme.reg
+   ```
+3. If you also want to enable dark theme for the Wine fork for your installed Affinity apps on Lutris, run the command:
+    ```shell
+   WINEPREFIX="$HOME/Games/affinity-suite" wine regedit wine-dark-theme.reg
+   ```

--- a/Guides/Lutris/Guide.md
+++ b/Guides/Lutris/Guide.md
@@ -137,5 +137,7 @@ To enable the dark theme for Wine, follow these steps:
    ```
 3. If you also want to enable dark theme for the Wine fork for your installed Affinity apps on Lutris, run the command:
     ```shell
-   WINEPREFIX="$HOME/Games/affinity-suite" wine regedit wine-dark-theme.reg
+   WINEPREFIX="$HOME/path/to/wineprefix" wine regedit wine-dark-theme.reg
    ```
+   - To check your Affinity app's Wine prefix, launch Lutris, then right click on an Affinity app, and select `Configure` from the menu. Under the `Game options` tab, check the `Wine prefix` field.
+   - Replace `$HOME/path/to/wineprefix` in the command above with the Wine prefix of your installed Affinity app.

--- a/Guides/Lutris/Guide.md
+++ b/Guides/Lutris/Guide.md
@@ -137,7 +137,7 @@ To enable the dark theme for Wine, follow these steps:
    ```
 3. If you also want to enable dark theme for the Wine fork for your installed Affinity apps on Lutris, run the command:
     ```shell
-   WINEPREFIX="$HOME/path/to/wineprefix" wine regedit wine-dark-theme.reg
+   WINEPREFIX="/path/to/wineprefix" wine regedit wine-dark-theme.reg
    ```
    - To check your Affinity app's Wine prefix, launch Lutris, then right click on an Affinity app, and select `Configure` from the menu. Under the `Game options` tab, check the `Wine prefix` field.
-   - Replace `$HOME/path/to/wineprefix` in the command above with the Wine prefix of your installed Affinity app.
+   - Replace `/path/to/wineprefix` in the command above with the Wine prefix of your installed Affinity app.

--- a/Guides/Lutris/Guide.md
+++ b/Guides/Lutris/Guide.md
@@ -101,14 +101,14 @@ After installing one Affinity app using the steps above, you can install the oth
 5. Edit the `Name` and `Identifier` fields under the `Game Info` tab.
 6. Set the correct `.exe` under the `Game Options` tab.
 
-## Optional: Set Icon and Cover Art for Affinity in Lutris
+## Optional: Set Icon, Cover Art and Banner for Affinity in Lutris
 
-After installing an Affinity app with Lutris, you can set the icon and cover art for the Affinity app.
+After installing an Affinity app with Lutris, you can set the icon, cover art and banner for the Affinity app.
 
 1. Right click an Affinity app entry, then select `Configure`.
-2. Under the `Game info` tab, set custom icon and cover art.
+2. Under the `Game info` tab, set custom icon, cover art and banner.
 
-You can find icons and cover art for Affinity apps from the AffinityOnLinux repository's [`Assets/Icons`](/Assets/Icons) and [`Assets/Covers`](/Assets/Covers) directories.
+You can find icons, cover art and banner for Affinity apps from the AffinityOnLinux repository's [`Assets/Icons`](/Assets/Icons) and [`Assets/Covers`](/Assets/Covers) directories.
 
 Make sure the `Identifier` has been changed to the corresponding name of each different Affinity app, as instructed the above steps to configure your Affinity apps' executable paths, otherwise Lutris will make the icons and cover art the same across all the different Affinity apps.
 

--- a/Guides/README.MD
+++ b/Guides/README.MD
@@ -2,6 +2,6 @@
 
 Click to the folder of your Wine manager for a guide to run Affinity Suite with your Wine manager of choice.
 
-Cover art can be found on the repository's [`Assets/Covers`](/Assets/Covers) directory.
+Cover art and banners can be found on the repository's [`Assets/Covers`](/Assets/Covers) directory.
 
 [Lutris](https://github.com/seapear/AffinityOnLinux/blob/main/Guides/Lutris/Guide.md) is recommended.


### PR DESCRIPTION
This PR aims to expand the instructions for enabling dark theme for Wine, including steps to download the dark theme registry file and running the registry file in the Wine prefix of Affinity apps.

With the addition of cover banners to the repository, I also added mention to the banners in the Lutris guide.