### PR TITLE
Lutris: fix install script link and add instructions to apply identifier change

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -58,7 +58,7 @@ As users of AffinityOnLinux ourselves, we know firsthand how valuable this tool 
 | [EndeavourOS](https://endeavouros.com/)   | ✔️     | ✔️     | ❓     | ✔️  |
 | [Nobara Linux](https://nobaraproject.org/)   | ✔️     | ✔️     | ❓     | ✔️  |
 | [SteamOS](https://store.steampowered.com/steamos)   | ✔️     | ✔️     | ❓     | ❓  |
-| [PopOS](https://system76.com/pop/)   | ❓     | ❓     | ❓     | [✔️](https://discord.com/channels/1281706644073611358/1281706644715208809/1419434351019687948)  |
+| [Pop!_OS](https://system76.com/pop/)   | ❓     | ❓     | ❓     | [✔️](https://discord.com/channels/1281706644073611358/1281706644715208809/1419434351019687948)  |
 
 Click on icon for more context if available:
 ❓ Untested

--- a/Guides/Lutris/Guide.md
+++ b/Guides/Lutris/Guide.md
@@ -74,7 +74,7 @@ Once the install of the Affinity app finishes, right click the Affinity app entr
     * `Affinity Designer`
     * `Affinity Publisher`
 
-3. (Recommended) Change the `Identifier` field to the correlated app name in lowercase and dashes:
+3. (Recommended) Change the `Identifier` field to the correlated app name in lowercase and dashes, and click "Apply" to apply the changes:
 
     * `affinity-photo`
     * `affinity-designer`

--- a/Guides/Lutris/Guide.md
+++ b/Guides/Lutris/Guide.md
@@ -55,7 +55,7 @@ If there is no `wine` folder inside your Lutris runners directory, create it, th
 1. Open Lutris and click on the plus icon on the top left corner of the window.
 2. Press "Install from a local install script".
 3. Download the install script for your Wine fork — Visit one of the following links based on your choice of Wine fork, then click the download button located on the top right of the file content to download the install script file, which is in YAML format.
-    - [ElementalWarrior](https://raw.githubusercontent.com/helenclx/AffinityOnLinux/refs/heads/main/Guides/Lutris/InstallScripts/Affinity-ew.yaml)
+    - [ElementalWarrior](/Guides/Lutris/InstallScripts/Affinity-ew.yaml)
     - [Wine-tkg-affinity](/Guides/Lutris/InstallScripts/Affinity-tkg.yaml)
 
 4. In Lutris, import the install script file for your Wine fork.


### PR DESCRIPTION
This PR aims to improve the guide to install Affinity Suite with Lutris, by fixing the link to the ElementalWarrior install script from a raw link file to a relative link file to be consistent with other install script links, and add instructions to apply change after changing the app identifier.