### PR TITLE
Lutris: Fix guide format and add shortcut creation section

### DIFF
--- a/Guides/Bottles/Guide.md
+++ b/Guides/Bottles/Guide.md
@@ -2,6 +2,8 @@
 
 <img src="/Assets/NewLogos/AffinityBottles.png" width="400"/>
 
+Before doing anything, make sure you have a `.exe` version of Affinity Photo, Affinity Designer, and/or Affinity Publisher downloaded from the official Affinity website: https://store.serif.com/en-us/account/downloads
+
 ## 1. Install Bottles
 
 Visit the [download page of Bottles' official website](https://usebottles.com/download/), and follow the instructions to download and install Bottles. [Flatpak](https://flathub.org/apps/com.usebottles.bottles) is recommended, as it is the only officially supported install method for Bottles.

--- a/Guides/Heroic/Guide.md
+++ b/Guides/Heroic/Guide.md
@@ -2,6 +2,8 @@
 
 <img src="/Assets/NewLogos/AffinityHGL.png" width="400"/>
 
+Before doing anything, make sure you have a `.exe` version of Affinity Photo, Affinity Designer, and/or Affinity Publisher downloaded from the official Affinity website: https://store.serif.com/en-us/account/downloads
+
 ## 1. Install Heroic Games Launcher
 
 Visit the [download page of Heroic Games Launcher's official website](https://heroicgameslauncher.com/downloads), and follow the instructions to download and install Heroic Games Launcher. [Flatpak](https://flathub.org/en/apps/com.heroicgameslauncher.hgl) is recommended.

--- a/Guides/Heroic/Guide.md
+++ b/Guides/Heroic/Guide.md
@@ -84,14 +84,20 @@ Quote from **darkside99**:
 
 ### Dark Theme for Wine
 
-1. Visit the [wine-dark-theme registry file](/Auxillary/Other/wine-dark-theme.reg) from this repository, and download the file by clicking the download button on the top right.
-2. In the folder where you downloaded the registry file into, run the following command:
-   ```shell
-   wine regedit wine-dark-theme.reg
-   ```
-3. If you also want to enable dark theme for the Wine fork for your installed Affinity apps on Heroic Games Launcher, run the command:
+1. Visit the [repository's `wine-dark-theme.reg` file page](/Auxillary/Other/wine-dark-theme.reg) to download the `.reg` file by clicking the download button on the top right.
+2. Save the file to your Downloads folder.
+3. Launch a terminal app to open the terminal, then type `cd Downloads` to change to your Downloads folder.
+4. Run the following command:
+    ```shell
+    wine regedit wine-dark-theme.reg
+    ```
+5. Press `Enter`. You might get a message again saying "Wine could not find a wine-mono package...". Just click `Install`.
+
+If you also want to enable dark theme for the Wine fork for your installed Affinity apps on Heroic Games Launcher:
+
+1. Launch Heroic Games Launcher.
+2. Click an Affinity app you installed. Under the **INSTALL INFO** section, check the **WinePrefix folder** path.
+3. Run the following command, and replace `/path/to/wineprefix` with the WinePrefix folder path:
     ```shell
    WINEPREFIX="/path/to/wineprefix/folder" wine regedit wine-dark-theme.reg
    ```
-   - To check your Affinity app's Wine prefix, launch Heroic Games Launcher, then click an Affinity app. Under the **INSTALL INFO** section, check the **WinePrefix folder**.
-   - Replace `/path/to/wineprefix/folder` in the command above with the WinePrefix folder location of your installed Affinity app.

--- a/Guides/Lutris/Guide.md
+++ b/Guides/Lutris/Guide.md
@@ -110,7 +110,7 @@ At this point, you should be in the 🎮 Games section of Lutris where a blank r
 
 At this point, you may wish to install other Affinity apps, fix scaling issues for high resolution screens, or enable a dark theme for Wine. If any of these apply to you, keep reading:
 
-### Installing other Affinity apps
+## Installing other Affinity apps
 
 After installing one Affinity app using the steps above, you can install the others to the same Wine prefix as follows:
 
@@ -122,7 +122,7 @@ After installing one Affinity app using the steps above, you can install the oth
 5. Edit the `Name` and `Identifier` fields under the `Game Info` tab.
 6. Set the correct `.exe` under the `Game Options` tab.
 
-### Fixing Scaling on HiDPI Screens
+## Fixing Scaling on HiDPI Screens
 
 To adjust the scaling of Affinity apps' UI on high resolution monitors, follow these steps:
 
@@ -134,7 +134,7 @@ To adjust the scaling of Affinity apps' UI on high resolution monitors, follow t
 
 Note that these Wine configuration settings will apply to all Affinity apps you installed with Lutris, since they share the same Wine prefix.
 
-### Dark Theme for Wine
+## Dark Theme for Wine
 
 To enable the dark theme for Wine, follow these steps:
 

--- a/Guides/Lutris/Guide.md
+++ b/Guides/Lutris/Guide.md
@@ -65,12 +65,7 @@ This is also known as your Wine runner.
 5. Press `Install`, then press `Install` again.
 6. Select or create a file path for where you would like everything to install, such as `/home/$USER/AffinityOnLinux`
 7. Select Affinity's setup file by pressing on the `⋮` three vertical dots button then choosing the `.exe` for Affinity Photo, Affinity Designer, or Affinity Publisher
-8. Press `Install`.
-
-At this point, you may get a message saying "Wine could not find a wine-mono package...". Go ahead and click `Install`.
-
-You will see a bunch of code running in a terminal-like space. This may take several minutes.
-
+8. Press `Install`. At this point, you may get a message saying "Wine could not find a wine-mono package...". Go ahead and click `Install`. You will see a bunch of code running in a terminal-like space. This may take several minutes.
 9. Once the terminal stuff is done, an Affinity window should pop up with a button to `Install`. Let it install, then once it's done click `Close`.
 10. Click `Launch` - you will now see an error message from Lutris that says 'This game has no executable set. The install process didn't finish properly.' Just click `OK` - we will address this in the next step.
 

--- a/Guides/Lutris/Guide.md
+++ b/Guides/Lutris/Guide.md
@@ -152,17 +152,20 @@ Note that these Wine configuration settings will apply to all Affinity apps you 
 
 To enable the dark theme for Wine, follow these steps:
 
-1. Click [here](/Auxillary/Other/wine-dark-theme.reg) to download a `.reg` file by clicking the download button on the top right just like we did for the `.yaml` file earlier
-2. Save the file to your Downloads folder
-3. Open Terminal, then type `cd Downloads` to change to your Downloads folder
+1. Visit the [repository's `wine-dark-theme.reg` file page](/Auxillary/Other/wine-dark-theme.reg) to download the `.reg` file by clicking the download button on the top right just like we did for the `.yaml` file earlier.
+2. Save the file to your Downloads folder.
+3. Launch a terminal app to open the terminal, then type `cd Downloads` to change to your Downloads folder.
 4. Run the following command:
     ```shell
     wine regedit wine-dark-theme.reg
     ```
 5. Press `Enter`. You might get a message again saying "Wine could not find a wine-mono package...". Just click `Install`.
-6. Launch Lutris, then right click on any Affinity app and select `Configure` from the menu
-7. Under the `Game options` tab, copy the filepath from the **`Wine prefix`** field
-8. Run the following command, replacing `/path/to/wineprefix` with the filepath you just copied
+
+If you also want to enable dark theme for the Wine fork for your installed Affinity apps on Lutris:
+
+1. Launch Lutris, then right click on any Affinity app and select `Configure` from the menu.
+2. Under the `Game options` tab, copy the file path from the **`Wine prefix`** field
+3. Run the following command, and replace `/path/to/wineprefix` with the file path you just copied:
    ```shell
    WINEPREFIX="/path/to/wineprefix" wine regedit wine-dark-theme.reg
    ```

--- a/Guides/Lutris/Guide.md
+++ b/Guides/Lutris/Guide.md
@@ -108,7 +108,21 @@ At this point, you should be in the 🎮 Games section of Lutris where a blank r
 5. Click `Save`
 6. Press `Play` to launch the app
 
-At this point, you may wish to install other Affinity apps, fix scaling issues for high resolution screens, or enable a dark theme for Wine. If any of these apply to you, keep reading:
+At this point, you may wish to create desktop and application shortcuts, install other Affinity apps, fix scaling issues for high resolution screens, or enable a dark theme for Wine. If any of these apply to you, keep reading:
+
+## Creating Desktop and Application Menu Shortcuts
+
+After you install an Affinity app with Lutris, you may notice that application menu shortcuts for the Affinity app were created by Wine in your system. However, it is recommended to create desktop and application menu shortcuts for Affinity apps with Lutris instead to ensure the shortcuts will launch the apps as intended.
+
+To remove application menu shortcuts created by Wine, visit the following directories, and remove shortcuts for Affinity apps:
+- `/home/$USER/.local/share/applications`
+- `/home/$USER/.config/menus/applications-merged`
+
+To create desktop and application menu shortcuts for Affinity apps with Lutris, follow these steps:
+
+1. Launch Lutris.
+2. Right click an Affinity app you have installed, then select `Create desktop shortcut`.
+3. Right click an Affinity app you have installed, then select `Create application menu shortcut`.
 
 ## Installing other Affinity apps
 

--- a/Guides/Lutris/Guide.md
+++ b/Guides/Lutris/Guide.md
@@ -146,7 +146,7 @@ To enable the dark theme for Wine, follow these steps:
 
 1. Visit the [repository's `wine-dark-theme.reg` file page](/Auxillary/Other/wine-dark-theme.reg) to download the `.reg` file by clicking the download button on the top right just like we did for the `.yaml` file earlier.
 2. Save the file to your Downloads folder.
-3. Launch a terminal app to open the terminal, then type `cd Downloads` to change to your Downloads folder.
+3. Launch your terminal app, then type `cd Downloads` to change to your Downloads folder.
 4. Run the following command:
     ```shell
     wine regedit wine-dark-theme.reg

--- a/Guides/Lutris/Guide.md
+++ b/Guides/Lutris/Guide.md
@@ -75,18 +75,15 @@ Congrats on making it this far! 🐧
 
 At this point, you should be in the 🎮 Games section of Lutris where a blank rectangle labeled `Affinity Suite` should exist. Right click on it and select `Configure` (should be the third option down).
 
-2. Under the first tab, `Game info`, change the `Name` field from Affinity Suite to the name of the app you just installed: Affinity Photo, Affinity Designer, or Affinity Publisher.
-
-3. Next to the `Identifier` field (towards the bottom), press `Change` then type in the correlated app name in lowercase and dashes, then press `Apply` to apply the change: 
+1. Under the first tab, `Game info`, change the `Name` field from Affinity Suite to the name of the app you just installed: Affinity Photo, Affinity Designer, or Affinity Publisher.
+2. Next to the `Identifier` field (towards the bottom), press `Change` then type in the correlated app name in lowercase and dashes, then press `Apply` to apply the change: 
     * `affinity-photo`
     * `affinity-designer`
     * `affinity-publisher`
-  
-4. You can find icons, cover art and banners for Affinity apps in AffinityOnLinux's [`Icons`](/Assets/Icons) and [`Covers`](/Assets/Covers) folders.
 
-3. Switch to the `Game options` tab. 
-4. In the **`Executable`** field, copy and paste one of the following:
-
+3. You can find icons, cover art and banners for Affinity apps in AffinityOnLinux's [`Icons`](/Assets/Icons) and [`Covers`](/Assets/Covers) folders.
+4. Switch to the `Game options` tab. 
+5. In the **`Executable`** field, copy and paste one of the following:
    Affinity Photo:
       ```shell
       drive_c/Program Files/Affinity/Photo 2/Photo.exe
@@ -100,8 +97,8 @@ At this point, you should be in the 🎮 Games section of Lutris where a blank r
       drive_c/Program Files/Affinity/Publisher 2/Publisher.exe
       ```
 
-5. Click `Save`
-6. Press `Play` to launch the app
+6. Click `Save`.
+7. Press `Play` to launch the app.
 
 At this point, you may wish to create desktop and application shortcuts, install other Affinity apps, fix scaling issues for high resolution screens, or enable a dark theme for Wine. If any of these apply to you, keep reading:
 

--- a/Guides/Lutris/Guide.md
+++ b/Guides/Lutris/Guide.md
@@ -63,13 +63,13 @@ This is also known as your Wine runner.
 3. Press "Install from a local install script".
 4. Press on the `⋮` three vertical dots button, then select the `.yaml` install script file you just downloaded for your Wine fork.
 5. Press `Install`, then press `Install` again.
-6. Select or create a file path for where you would like everything to install, such as `/home/$USER/AffinityOnLinux`
-7. Select Affinity's setup file by pressing on the `⋮` three vertical dots button then choosing the `.exe` for Affinity Photo, Affinity Designer, or Affinity Publisher
+6. Select or create a file path for where you would like everything to install, such as `/home/$USER/AffinityOnLinux`.
+7. Select Affinity's setup file by pressing on the `⋮` three vertical dots button then choosing the `.exe` for Affinity Photo, Affinity Designer, or Affinity Publisher.
 8. Press `Install`. At this point, you may get a message saying "Wine could not find a wine-mono package...". Go ahead and click `Install`. You will see a bunch of code running in a terminal-like space. This may take several minutes.
 9. Once the terminal stuff is done, an Affinity window should pop up with a button to `Install`. Let it install, then once it's done click `Close`.
 10. Click `Launch` - you will now see an error message from Lutris that says 'This game has no executable set. The install process didn't finish properly.' Just click `OK` - we will address this in the next step.
 
-(Congrats on making it this far!) 🐧
+Congrats on making it this far! 🐧
 
 ## 6. Get ready to launch
 

--- a/Guides/Lutris/Guide.md
+++ b/Guides/Lutris/Guide.md
@@ -4,7 +4,7 @@ Currently, Lutris is the best method for Nvidia GPU users.
 
 <img src="/Assets/NewLogos/AffinityLutris.png" width="400"/>
 
-Before doing anything, make sure you have a `.exe` version of Affinity Photo, Affinity Designer, and/or Affinity Publisher downloaded from their website: https://store.serif.com/en-us/account/downloads
+Before doing anything, make sure you have a `.exe` version of Affinity Photo, Affinity Designer, and/or Affinity Publisher downloaded from the official Affinity website: https://store.serif.com/en-us/account/downloads
 
 ## 1. Install winetricks
 

--- a/Guides/Lutris/Guide.md
+++ b/Guides/Lutris/Guide.md
@@ -52,7 +52,7 @@ Lutris' Wine-related folders can be found in a hidden directory within your `hom
 
 Create a folder called `wine` if one does not already exist, then copy and paste the folder you extracted in the previous step to this folder.
 
-This is also known as your "Wine runner."
+This is also known as your Wine runner.
 
 ## 5. Install Affinity with Lutris
 
@@ -61,19 +61,18 @@ This is also known as your "Wine runner."
     - [Wine-tkg-affinity](/Guides/Lutris/InstallScripts/Affinity-tkg.yaml) `Affinity-tkg.yaml`
 2. Open Lutris and click on the plus `+` icon on the top left corner of the window.
 3. Press "Install from a local install script".
-4. Press on the `⋮` three vertical dots button, then select the `.yaml` install script file you just downloaded for your Wine fork
-5. Press `Install`, then press `Install` again
-6. Select or create a filepath for where you would like everything to install, such as `/home/$USER/AffinityOnLinux`
-7. Check [✓] `Create desktop shortcut` and/or [✓] `Create application menu shortcut`, then press `Continue`
-8. Select Affinity's setup file by pressing on the `⋮` three vertical dots button then choosing the `.exe` for Affinity Photo, Affinity Designer, or Affinity Publisher
-9. Press `Install`.
+4. Press on the `⋮` three vertical dots button, then select the `.yaml` install script file you just downloaded for your Wine fork.
+5. Press `Install`, then press `Install` again.
+6. Select or create a file path for where you would like everything to install, such as `/home/$USER/AffinityOnLinux`
+7. Select Affinity's setup file by pressing on the `⋮` three vertical dots button then choosing the `.exe` for Affinity Photo, Affinity Designer, or Affinity Publisher
+8. Press `Install`.
 
 At this point, you may get a message saying "Wine could not find a wine-mono package...". Go ahead and click `Install`.
 
 You will see a bunch of code running in a terminal-like space. This may take several minutes.
 
-10. Once the terminal stuff is done, an Affinity window should pop up with a button to `Install`. Let it install, then once it's done click `Close`.
-11. Click `Launch` - you will now see an error message from Lutris that says 'This game has no executable set. The install process didn't finish properly.' Just click `OK` - we will address this in the next step.
+9. Once the terminal stuff is done, an Affinity window should pop up with a button to `Install`. Let it install, then once it's done click `Close`.
+10. Click `Launch` - you will now see an error message from Lutris that says 'This game has no executable set. The install process didn't finish properly.' Just click `OK` - we will address this in the next step.
 
 (Congrats on making it this far!) 🐧
 
@@ -81,9 +80,9 @@ You will see a bunch of code running in a terminal-like space. This may take sev
 
 At this point, you should be in the 🎮 Games section of Lutris where a blank rectangle labeled `Affinity Suite` should exist. Right click on it and select `Configure` (should be the third option down).
 
-2. Under the first tab, `Game info`, change the `Name` field from Affinity Suite to the name of the app you just installed (Affinity Photo, Affinity Designer, or Affinity Publisher)
+2. Under the first tab, `Game info`, change the `Name` field from Affinity Suite to the name of the app you just installed: Affinity Photo, Affinity Designer, or Affinity Publisher.
 
-3. Next to the the `Identifier` field (towards the bottom), press `Change` then type in the correlated app name in lowercase and dashes, then press `Apply` to apply the change: 
+3. Next to the `Identifier` field (towards the bottom), press `Change` then type in the correlated app name in lowercase and dashes, then press `Apply` to apply the change: 
     * `affinity-photo`
     * `affinity-designer`
     * `affinity-publisher`


### PR DESCRIPTION
This PR aims to improve the Lutris guide by:

- Fixing the guide's format, such as correcting the step order in the "Get ready to launch" section and fixing grammar.
- Adding a section for creating desktop and application menu shortcuts.

In addition, for the Heroic Games Launcher and Bottles guide, to improve consistency with the Lutris guide, an instruction for downloading Affinity apps are added, and the section for enabling dark theme for Wine has been elaborated.