### PR TITLE
Fix Canva sign-in crash and wintypes.dll install bug (#131)

### DIFF
--- a/Guides/Lutris/InstallScripts/Affinity-gd.yaml
+++ b/Guides/Lutris/InstallScripts/Affinity-gd.yaml
@@ -56,9 +56,13 @@ script:
         src: Windows.winmd
         dst: "$GAMEDIR/drive_c/windows/system32/winmetadata/Windows.winmd"
     - move:
-        description: Placing Wintypes_Shim.dll.so helper file (if provided)...
+        description: Placing wintypes.dll helper file (if provided)...
         src: Wintypes_Shim.dll.so
-        dst: "$GAMEDIR/drive_c/Program Files/Affinity/Affinity/Wintypes_Shim.dll.so"
+        dst: "$GAMEDIR/drive_c/Program Files/Affinity/Affinity/wintypes.dll"
+    - execute:
+        description: Registering wintypes as a native DLL override...
+        command: wine reg add "HKEY_CURRENT_USER\\Software\\Wine\\DllOverrides" /v wintypes /d native /f
+        prefix: $GAMEDIR
 
   files:
     - setup: https://downloads.affinity.studio/Affinity%20x64.exe

--- a/Guides/Wine/LoginFix/LoginFix.csproj
+++ b/Guides/Wine/LoginFix/LoginFix.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Product>LoginFix</Product>
+    <Description>Avoids the SharedStorageAccessManager WinRT crash on the Canva sign-in callback under Wine</Description>
+    <Version>0.1.0</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Lib.Harmony" Version="2.4.2" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="WindowsBase" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+  </ItemGroup>
+  <ItemGroup>
+    <!--
+      Copy AffinityPluginLoader.dll (from your Affinity install directory, after following this
+      guide's "Install Affinity Plugin Loader + WineFix" step) into this same folder before
+      building. See README.md.
+    -->
+    <Reference Include="AffinityPluginLoader">
+      <HintPath>./AffinityPluginLoader.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/Guides/Wine/LoginFix/LoginFixPlugin.cs
+++ b/Guides/Wine/LoginFix/LoginFixPlugin.cs
@@ -1,0 +1,25 @@
+using HarmonyLib;
+using AffinityPluginLoader;
+using AffinityPluginLoader.Settings;
+
+namespace LoginFix
+{
+    /// <summary>
+    /// Works around a Wine WinRT gap that crashes the Canva sign-in callback.
+    /// </summary>
+    public class LoginFixPlugin : AffinityPlugin
+    {
+        public const string PluginId = "loginfix";
+
+        public override PluginSettingsDefinition DefineSettings()
+        {
+            return new PluginSettingsDefinition(PluginId);
+        }
+
+        public override void OnPatch(Harmony harmony, IPluginContext context)
+        {
+            context.Patch("ProcessCommandLineArguments fix",
+                h => Patches.ProcessCommandLineArgumentsPatch.ApplyPatches(h));
+        }
+    }
+}

--- a/Guides/Wine/LoginFix/Patches/ProcessCommandLineArgumentsPatch.cs
+++ b/Guides/Wine/LoginFix/Patches/ProcessCommandLineArgumentsPatch.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using HarmonyLib;
+using AffinityPluginLoader.Core;
+
+namespace LoginFix.Patches
+{
+    /// <summary>
+    /// Serif.Affinity.Application.ProcessCommandLineArguments references
+    /// Windows.ApplicationModel.DataTransfer.SharedStorageAccessManager (only reached for
+    /// "affinity-open-file:" arguments). Wine has no WinRT implementation for that type, and the
+    /// CLR resolves every type referenced in a method body when it JITs the method - so any call
+    /// into ProcessCommandLineArguments throws System.TypeLoadException, including the unrelated
+    /// "affinity://" OAuth callback path the sign-in flow depends on.
+    ///
+    /// Harmony itself can't patch ProcessCommandLineArguments directly either: patching requires
+    /// decompiling the target method's IL (even for a plain prefix, to build the merged
+    /// dispatcher), which means resolving every operand in its body - including the poisoned
+    /// SharedStorageAccessManager call - and that resolution throws the same way the JIT does.
+    ///
+    /// Both of ProcessCommandLineArguments' callers only reference it by signature (safe to
+    /// resolve), not by body, so patching *them* instead works: ProcessArguments() handles the
+    /// app's own startup command line, and SingleInstanceThread() receives arguments forwarded
+    /// over a named pipe by a second launched instance (this is the path the Canva sign-in
+    /// callback actually takes). Both patches fully replace their target with a safe
+    /// reimplementation that never touches the real ProcessCommandLineArguments.
+    /// </summary>
+    public static class ProcessCommandLineArgumentsPatch
+    {
+        static readonly HashSet<string> KnownFlags = new HashSet<string>
+        {
+            "--gpu-telemetry", "--no-dwm-warning", "--hw-ui", "--no-hw-ui", "--no-ocl",
+            "--click-through", "--no-click-through", "--input-logging", "--printmode1",
+            "--disable-cltest", "--disable-font-preview-cache",
+            "--disable-parallel-font-enumeration", "--font-cache-logging",
+            "--full-crash-dumps", "--disable-wintab", "--legacy-wintab",
+        };
+
+        static Type _applicationType;
+
+        public static void ApplyPatches(Harmony harmony)
+        {
+            Logger.Info("Applying command-line argument patches (Wine SharedStorageAccessManager fix)...");
+
+            var serifAssembly = AppDomain.CurrentDomain.GetAssemblies()
+                .FirstOrDefault(a => a.GetName().Name == "Serif.Affinity");
+            if (serifAssembly == null)
+            {
+                Logger.Error("Serif.Affinity assembly not found");
+                return;
+            }
+
+            _applicationType = serifAssembly.GetType("Serif.Affinity.Application");
+            if (_applicationType == null)
+            {
+                Logger.Error("Serif.Affinity.Application type not found");
+                return;
+            }
+
+            var processArguments = AccessTools.Method(_applicationType, "ProcessArguments", Type.EmptyTypes);
+            if (processArguments == null)
+            {
+                Logger.Error("ProcessArguments() not found");
+            }
+            else
+            {
+                harmony.Patch(processArguments,
+                    prefix: new HarmonyMethod(AccessTools.Method(typeof(ProcessCommandLineArgumentsPatch), nameof(ProcessArgumentsPrefix))));
+                Logger.Info("Patched ProcessArguments (startup command line)");
+            }
+
+            var singleInstanceThread = AccessTools.Method(_applicationType, "SingleInstanceThread", Type.EmptyTypes);
+            if (singleInstanceThread == null)
+            {
+                Logger.Error("SingleInstanceThread() not found");
+            }
+            else
+            {
+                harmony.Patch(singleInstanceThread,
+                    prefix: new HarmonyMethod(AccessTools.Method(typeof(ProcessCommandLineArgumentsPatch), nameof(SingleInstanceThreadPrefix))));
+                Logger.Info("Patched SingleInstanceThread (activation via named pipe - the sign-in callback path)");
+            }
+        }
+
+        // Replaces Application.ProcessArguments(). Mirrors the original's fallback chain
+        // (live command line, then per-user arguments.cfg, then per-machine arguments.cfg)
+        // but routes everything through SafeProcessCommandLineArguments instead of the
+        // real (poisoned) ProcessCommandLineArguments.
+        static bool ProcessArgumentsPrefix(object __instance)
+        {
+            try
+            {
+                var setCommandLineArguments = AccessTools.Method(_applicationType, "SetCommandLineArguments", new[] { typeof(string[]) });
+                setCommandLineArguments?.Invoke(__instance, new object[] { Environment.GetCommandLineArgs() });
+
+                SafeProcessCommandLineArguments(__instance, Environment.GetCommandLineArgs().Skip(1));
+
+                bool handledFromFile = false;
+                var appDataPathForCurrentUser = (string)AccessTools.Property(_applicationType.BaseType, "AppDataPathForCurrentUser")?.GetValue(__instance);
+                if (appDataPathForCurrentUser != null)
+                {
+                    try
+                    {
+                        var lines = File.ReadAllText(Path.Combine(appDataPathForCurrentUser, "arguments.cfg"))
+                            .Split(new[] { "\r\n", "\n", "\t", " " }, StringSplitOptions.RemoveEmptyEntries);
+                        if (lines.Length != 0)
+                        {
+                            SafeProcessCommandLineArguments(__instance, lines);
+                            handledFromFile = true;
+                        }
+                    }
+                    catch { }
+                }
+
+                if (!handledFromFile)
+                {
+                    var appDataPathForAllUsers = (string)AccessTools.Property(_applicationType.BaseType, "AppDataPathForAllUsers")?.GetValue(__instance);
+                    if (appDataPathForAllUsers != null)
+                    {
+                        try
+                        {
+                            var lines = File.ReadAllText(Path.Combine(appDataPathForAllUsers, "arguments.cfg"))
+                                .Split(new[] { "\r\n", "\n", "\t", " " }, StringSplitOptions.RemoveEmptyEntries);
+                            if (lines.Length != 0)
+                            {
+                                SafeProcessCommandLineArguments(__instance, lines);
+                            }
+                        }
+                        catch { }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("ProcessArguments replacement failed: " + ex);
+            }
+
+            return false;
+        }
+
+        // Replaces the static Application.SingleInstanceThread(). Mirrors the original's named
+        // pipe server loop exactly, except the received arguments are handed to
+        // SafeProcessCommandLineArguments on the dispatcher instead of the real
+        // ProcessCommandLineArguments.
+        static bool SingleInstanceThreadPrefix()
+        {
+            try
+            {
+                var application = System.Windows.Application.Current;
+                var isClosingProp = AccessTools.Property(_applicationType.BaseType, "IsClosing")
+                                     ?? AccessTools.Property(_applicationType, "IsClosing");
+                var singleInstanceIdProp = AccessTools.Property(_applicationType, "SingleInstanceId");
+                var delayDocumentOpenField = AccessTools.Field(_applicationType, "m_delayDocumentOpen");
+
+                Func<bool> isClosing = () => (bool)isClosingProp.GetValue(application);
+                string singleInstanceId = (string)singleInstanceIdProp.GetValue(application);
+
+                while (!isClosing())
+                {
+                    try
+                    {
+                        using (var server = new NamedPipeServerStream(singleInstanceId))
+                        {
+                            server.WaitForConnection();
+                            while ((bool)delayDocumentOpenField.GetValue(application))
+                            {
+                                Thread.Sleep(500);
+                            }
+                            if (isClosing()) continue;
+
+                            try
+                            {
+                                using (var reader = new BinaryReader(server))
+                                {
+                                    string text = reader.ReadString();
+                                    var arguments = text.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                                    var argsToProcess = arguments.Skip(1).ToArray();
+                                    application.Dispatcher.BeginInvoke((Action)(() =>
+                                    {
+                                        SafeProcessCommandLineArguments(application, argsToProcess);
+                                    }));
+                                }
+                            }
+                            catch { }
+                        }
+                    }
+                    catch { }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("SingleInstanceThread replacement failed: " + ex);
+            }
+
+            return false;
+        }
+
+        // Safe stand-in for Application.ProcessCommandLineArguments(IEnumerable<string>).
+        // Drops "affinity-open-file:" support (needs SharedStorageAccessManager, unsupported
+        // under Wine either way); everything else matches the original's behavior.
+        static void SafeProcessCommandLineArguments(object instance, IEnumerable<string> arguments)
+        {
+            string callbackUrl = null;
+            var paths = new List<string>();
+
+            foreach (var argument in arguments)
+            {
+                var lower = argument.ToLowerInvariant();
+                if (KnownFlags.Contains(lower)) continue;
+                if (lower.StartsWith("affinity-open-file:"))
+                {
+                    Logger.Warning("Ignoring affinity-open-file: argument (needs SharedStorageAccessManager, unsupported under Wine)");
+                    continue;
+                }
+                if (lower.StartsWith("affinity://"))
+                {
+                    callbackUrl = argument;
+                    continue;
+                }
+                paths.Add(argument);
+            }
+
+            bool mainWindowLoaded = (bool)AccessTools.Field(_applicationType, "m_mainWindowLoaded").GetValue(instance);
+            var activateMainWindow = AccessTools.Method(_applicationType, "ActivateMainWindow");
+            var loadFiles = AccessTools.Method(_applicationType, "LoadFiles", new[] { typeof(List<string>) });
+
+            if (mainWindowLoaded)
+            {
+                activateMainWindow.Invoke(instance, null);
+                loadFiles.Invoke(instance, new object[] { paths });
+            }
+            else
+            {
+                var pathsToLoad = (List<string>)AccessTools.Field(_applicationType, "m_pathsToLoad").GetValue(instance);
+                foreach (var p in paths)
+                {
+                    if (!pathsToLoad.Contains(p)) pathsToLoad.Add(p);
+                }
+                activateMainWindow.Invoke(instance, null);
+            }
+
+            if (!string.IsNullOrEmpty(callbackUrl))
+            {
+                var openUrl = AccessTools.Method(_applicationType, "OpenUrl", new[] { typeof(string) });
+                openUrl.Invoke(instance, new object[] { callbackUrl });
+            }
+        }
+    }
+}

--- a/Guides/Wine/LoginFix/inject-login.sh
+++ b/Guides/Wine/LoginFix/inject-login.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Manually hand an affinity:// OAuth callback URL to Affinity, bypassing the
+# OS-level "Open Affinity?" protocol-handler confirmation dialog entirely.
+#
+# Use this if the browser-to-Affinity handoff isn't completing on its own
+# (for example, while testing a fresh Wine prefix, or if your desktop's
+# protocol-handler dialog isn't wired up yet). With LoginFix installed and
+# working normally, you should not need this, sign-in completes on its own.
+#
+# Get the callback URL from your browser's address bar (or via "copy link"
+# on the "Open Affinity?" page) right before it would normally hand off to
+# Affinity, then paste it here. The pasted value is never echoed, never
+# written to disk, and never touches shell history (read -s, not a typed
+# command).
+set -euo pipefail
+
+WINEPREFIX="${WINEPREFIX:-$HOME/.affinity}"
+WINE_BIN="${WINE_BIN:-wine}"
+
+read -rs -p "Paste the affinity:// callback URL, then press Enter: " CALLBACK_URL
+echo
+echo
+
+if [[ "$CALLBACK_URL" != affinity://* ]]; then
+    echo "That doesn't look like an affinity:// URL. Aborting." >&2
+    exit 1
+fi
+
+echo "Invoking Wine with the callback..."
+WINEPREFIX="$WINEPREFIX" "$WINE_BIN" start "$CALLBACK_URL"

--- a/Guides/Wine/Script Installer/affinity_installer_unified.py
+++ b/Guides/Wine/Script Installer/affinity_installer_unified.py
@@ -413,24 +413,32 @@ install_affinity_app() {
     
     # Copy helper files
     local affinity_dir="$WINEPREFIX/drive_c/Program Files/Affinity"
-    
-    if [ -d "$affinity_dir" ]; then
-        local app_dir=$(find "$affinity_dir" -maxdepth 1 -type d \( -name "Affinity*" -o -name "Affinity" \) | head -1)
-        
-        if [ -n "$app_dir" ] && [ -f "$WINTYPES_DLL" ]; then
+
+    if [ -d "$affinity_dir" ] && [ -f "$WINTYPES_DLL" ]; then
+        # V2 installs (Photo 2, Designer 2, Publisher 2) each get their own
+        # subdirectory here, so every match needs the shim, not just the first.
+        while IFS= read -r app_dir; do
             cp "$WINTYPES_DLL" "$app_dir/" 2>&1 | tee -a "$LOG_FILE"
             log "wintypes.dll copied to $app_dir"
-        fi
+        done < <(find "$affinity_dir" -maxdepth 1 -type d \( -name "Affinity*" -o -name "Affinity" \))
     fi
-    
+
     local winmetadata_dir="$WINEPREFIX/drive_c/windows/system32/WinMetadata"
     mkdir -p "$winmetadata_dir"
-    
+
     if [ -f "$WINDOWS_WINMD" ]; then
         cp "$WINDOWS_WINMD" "$winmetadata_dir/" 2>&1 | tee -a "$LOG_FILE"
         log "Windows.winmd copied to $winmetadata_dir"
     fi
-    
+
+    # Register the wintypes native DLL override so Wine actually loads the
+    # shim above instead of its own missing wintypes.dll (#131 root cause).
+    if [ -f "$WINTYPES_DLL" ]; then
+        WINEPREFIX="$WINEPREFIX" wine reg add "HKEY_CURRENT_USER\\Software\\Wine\\DllOverrides" \
+            /v wintypes /d native /f 2>&1 | tee -a "$LOG_FILE"
+        log "Registered wintypes native DLL override"
+    fi
+
     return 0
 }
 
@@ -1389,7 +1397,7 @@ class AffinityInstallerGUI(QMainWindow):
         
         # Credits link
         credits_label = QLabel(
-            "<b><a href='https://github.com/seapear/AffinityOnLinux/blob/main/Credits.md' style='color: #2196F3; text-decoration: none;'>Credits</a></b> - "
+            "<b><a href='https://github.com/seapear/AffinityOnLinux/wiki/Credits' style='color: #2196F3; text-decoration: none;'>Credits</a></b> - "
             "Credit to all the amazing work everyone has volunteered"
         )
         credits_label.setOpenExternalLinks(True)

--- a/Guides/Wine/wine-11.15-sdr-white-level.patch
+++ b/Guides/Wine/wine-11.15-sdr-white-level.patch
@@ -1,0 +1,44 @@
+--- a/dlls/win32u/sysparams.c
++++ b/dlls/win32u/sysparams.c
+@@ -7903,12 +7903,40 @@
+         unlock_display_devices();
+         return ret;
+     }
++    case DISPLAYCONFIG_DEVICE_INFO_GET_SDR_WHITE_LEVEL:
++    {
++        DISPLAYCONFIG_SDR_WHITE_LEVEL *white_level = (DISPLAYCONFIG_SDR_WHITE_LEVEL *)packet;
++        struct monitor *monitor;
++
++        FIXME( "DISPLAYCONFIG_DEVICE_INFO_GET_SDR_WHITE_LEVEL semi-stub.\n" );
++
++        if (packet->size < sizeof(*white_level))
++            return STATUS_INVALID_PARAMETER;
++
++        if (!lock_display_devices( FALSE )) return STATUS_UNSUCCESSFUL;
++
++        LIST_FOR_EACH_ENTRY(monitor, &monitors, struct monitor, entry)
++        {
++            if (white_level->header.id != monitor->output_id) continue;
++            if (memcmp( &white_level->header.adapterId, &monitor->source->gpu->luid,
++                        sizeof(monitor->source->gpu->luid) ))
++                continue;
++
++            /* 1000 == 80 nits, the documented reference white level for SDR content. */
++            white_level->SDRWhiteLevel = 1000;
++
++            ret = STATUS_SUCCESS;
++            break;
++        }
++
++        unlock_display_devices();
++        return ret;
++    }
+     case DISPLAYCONFIG_DEVICE_INFO_SET_TARGET_PERSISTENCE:
+     case DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_BASE_TYPE:
+     case DISPLAYCONFIG_DEVICE_INFO_GET_SUPPORT_VIRTUAL_RESOLUTION:
+     case DISPLAYCONFIG_DEVICE_INFO_SET_SUPPORT_VIRTUAL_RESOLUTION:
+     case DISPLAYCONFIG_DEVICE_INFO_SET_ADVANCED_COLOR_STATE:
+-    case DISPLAYCONFIG_DEVICE_INFO_GET_SDR_WHITE_LEVEL:
+     default:
+         FIXME( "Unimplemented packet type %u.\n", packet->type );
+         return STATUS_INVALID_PARAMETER;


### PR DESCRIPTION
## Summary

- Adds LoginFix, a plugin that fixes the Canva sign-in crash under Wine.
- Fixes the wintypes.dll install bug from #131 (wrong filename, missing DLL override, and only copying to the first app folder).
- Adds a small Wine source patch for a separate Direct3D startup crash.

## Details

### LoginFix

Affinity by Canva's sign-in flow used to crash Affinity under Wine. The crash traces to `Serif.Affinity.Application.ProcessCommandLineArguments`. This method references a WinRT type Wine does not implement (`SharedStorageAccessManager`). The .NET CLR resolves every type in a method body at JIT time. So any call into that method throws `TypeLoadException`, including the OAuth callback path.

LoginFix patches the method's two callers instead. Both callers only reference the poisoned type by signature, so [Harmony](https://github.com/pardeike/Harmony) can patch them safely. This plugin runs through [AffinityPluginLoader](https://github.com/noahc3/AffinityPluginLoader).

Also includes `inject-login.sh`. This is a manual fallback script. Use it to hand an `affinity://` callback to Wine directly, if the OS-level protocol handoff does not complete on its own.

### wintypes.dll fix (#131)

The install scripts copied the wintypes shim under its original filename, `Wintypes_Shim.dll.so`, instead of `wintypes.dll`. They also never registered the native DLL override. So Wine loaded its own incomplete `wintypes.dll` instead of the shim.

A second bug: the shim was only copied to the first matching Affinity app folder. Installing multiple V2 apps (Photo 2, Designer 2, Publisher 2) needs a copy in each app's own folder.

Both bugs are fixed in the script installer and the Lutris install script.

### Wine source patch

Affinity's Direct3D device creation fails when Wine does not implement the SDR white level query (`DISPLAYCONFIG_DEVICE_INFO_GET_SDR_WHITE_LEVEL`). This is a separate startup crash, unrelated to the sign-in crash above. The patch (`Guides/Wine/wine-11.15-sdr-white-level.patch`) returns a default value of 1000, the standard 80-nit SDR reference white level, instead of an error. Tested against Wine 11.15.

## Test plan

- [x] LoginFix confirmed working end to end on a manual Wine install and on Lutris, on stock distro Wine 11.15.
- [x] wintypes.dll fix confirmed against the script installer and Lutris install script.
- [x] Wine patch built and tested against Wine 11.15, confirmed it fixes the Direct3D device creation crash.
